### PR TITLE
Fixes raw guardrail output paths breaks intellij import

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -41,7 +41,7 @@ trait Deps {
   def scalaVersion: String = "2.13.13"
   def testWithMill: Seq[String]
 
-  def mimaPreviousVersions: Seq[String] = Seq()
+  def mimaPreviousVersions: Seq[String] = Seq("0.0.1-RC-5", "0.0.1-RC-6")
 
   private val guardrailVersion = "1.0.0-M1"
 

--- a/itest/src/pet-shop-full/build.sc
+++ b/itest/src/pet-shop-full/build.sc
@@ -43,46 +43,68 @@ object `pet-shop-full` extends ScalaModule with Guardrail {
   def verify(): Command[Unit] = T.command {
     compile()
     val expectedSources = Set(
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Order.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/User.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/ApiResponse.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/package.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Tag.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/User.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/support/Presence.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/package.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/ApiResponse.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/support/Presence.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/ApiResponse.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Order.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Pet.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Customer.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Tag.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/package.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Category.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/Client.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/support/Presence.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/Http4sImplicits.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/Routes.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Address.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/User.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/Implicits.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Category.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Customer.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Tag.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Category.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Pet.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Address.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/Implicits.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/Implicits.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/Http4sImplicits.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Address.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Pet.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Order.scala",
-      s"pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Customer.scala"
+      "pet-shop-full/guardrailGenerate.dest/guardrail",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/server",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/server/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Order.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/User.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/ApiResponse.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/package.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Tag.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/User.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/support/Presence.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/package.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/ApiResponse.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/support/Presence.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/ApiResponse.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Order.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Pet.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Customer.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Tag.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/package.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Category.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/Client.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/support/Presence.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/Http4sImplicits.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/Routes.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Address.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/User.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/Implicits.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Category.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Customer.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Tag.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Category.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Pet.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Address.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/Implicits.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/Implicits.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/Http4sImplicits.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions/Address.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Pet.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/server/definitions/Order.scala",
+      "pet-shop-full/out/pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions/Customer.scala"
     )
+    val generated = generatedSources().flatMap { entry =>
+      val withoutRefRegex = """^(?:[^:]+:){3}(.*)$""".r
+      val justPetShopFullRegex = """^.*/(pet-shop-full/.*)$""".r
+      val withoutRef = withoutRefRegex.replaceAllIn(
+        entry.toString.replaceAllLiterally("\\", "/"),
+        "$1"
+      )
+      os.walk(os.Path(withoutRef))
+        .map(f =>
+          justPetShopFullRegex
+            .replaceAllIn(f.toString().replaceAllLiterally("\\", "/"), "$1")
+        )
+    }
     assert(
-      generatedSources().exists(f =>
+      generated.exists(f =>
         expectedSources.exists(e =>
           f.toString.replaceAllLiterally("\\", "/").contains(e.toString)
         )

--- a/itest/src/pet-shop-no-server/build.sc
+++ b/itest/src/pet-shop-no-server/build.sc
@@ -55,35 +55,54 @@ object `pet-shop-no-server` extends ScalaModule with Guardrail {
 
   def verify(): Command[Unit] = T.command {
     compile()
-    println(allSources())
     val expectedSources = Set(
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Order.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/User.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/ApiResponse.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/User.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/package.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/ApiResponse.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/support/Presence.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Order.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Pet.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Tag.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/package.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/Client.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/support/Presence.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Category.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Customer.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Tag.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Category.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Pet.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Address.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/Implicits.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/Implicits.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/Http4sImplicits.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Address.scala",
-      s"pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Customer.scala"
+      "pet-shop-full/guardrailGenerate.dest/guardrail",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Order.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/User.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/ApiResponse.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/User.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/package.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/ApiResponse.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/support/Presence.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Order.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Pet.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Tag.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/package.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/Client.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/support/Presence.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Category.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Customer.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Tag.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Category.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Pet.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Address.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/Implicits.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/Implicits.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/Http4sImplicits.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/models/definitions/Address.scala",
+      "pet-shop-no-server/out/pet-shop-no-server/guardrailGenerate.dest/guardrail/client/definitions/Customer.scala"
     )
+    val generated = generatedSources().flatMap { entry =>
+      val withoutRefRegex = """^(?:[^:]+:){3}(.*)$""".r
+      val justPetShopFullRegex = """^.*/(pet-shop-full/.*)$""".r
+      val withoutRef = withoutRefRegex.replaceAllIn(
+        entry.toString.replaceAllLiterally("\\", "/"),
+        "$1"
+      )
+      os.walk(os.Path(withoutRef))
+        .map(f =>
+          justPetShopFullRegex
+            .replaceAllIn(f.toString().replaceAllLiterally("\\", "/"), "$1")
+        )
+    }
     assert(
-      generatedSources().exists(f =>
+      generated.exists(f =>
         expectedSources.exists(e =>
           f.toString.replaceAllLiterally("\\", "/").contains(e.toString)
         )

--- a/itest/src/pet-shop-scala-akka-http-jackson/build.sc
+++ b/itest/src/pet-shop-scala-akka-http-jackson/build.sc
@@ -70,8 +70,16 @@ object `pet-shop-scala-akka-http-jackson` extends ScalaModule with Guardrail {
 
   def verify(): Command[Unit] = T.command {
     compile()
-    println(allSources())
     val expectedSources = Set(
+      "pet-shop-full/guardrailGenerate.dest/guardrail",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/server",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/server/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions",
       "pet-shop-scala-akka-http-jackson/guardrailGenerate.dest/guardrail/client/definitions/Address.scala",
       "pet-shop-scala-akka-http-jackson/guardrailGenerate.dest/guardrail/client/definitions/ApiResponse.scala",
       "pet-shop-scala-akka-http-jackson/guardrailGenerate.dest/guardrail/client/definitions/Category.scala",
@@ -116,8 +124,21 @@ object `pet-shop-scala-akka-http-jackson` extends ScalaModule with Guardrail {
       "pet-shop-scala-akka-http-jackson/guardrailGenerate.dest/guardrail/models/support/Presence.scala",
       "pet-shop-scala-akka-http-jackson/guardrailGenerate.dest/guardrail/models/support/EmptyIsNullDeserializers.scala"
     )
+    val generated = generatedSources().flatMap { entry =>
+      val withoutRefRegex = """^(?:[^:]+:){3}(.*)$""".r
+      val justPetShopFullRegex = """^.*/(pet-shop-full/.*)$""".r
+      val withoutRef = withoutRefRegex.replaceAllIn(
+        entry.toString.replaceAllLiterally("\\", "/"),
+        "$1"
+      )
+      os.walk(os.Path(withoutRef))
+        .map(f =>
+          justPetShopFullRegex
+            .replaceAllIn(f.toString().replaceAllLiterally("\\", "/"), "$1")
+        )
+    }
     assert(
-      generatedSources().exists(f =>
+      generated.exists(f =>
         expectedSources.exists(e =>
           f.toString.replaceAllLiterally("\\", "/").contains(e.toString)
         )

--- a/itest/src/pet-shop-scala-akka-http/build.sc
+++ b/itest/src/pet-shop-scala-akka-http/build.sc
@@ -70,8 +70,16 @@ object `pet-shop-scala-akka-http` extends ScalaModule with Guardrail {
 
   def verify(): Command[Unit] = T.command {
     compile()
-    println(allSources())
     val expectedSources = Set(
+      "pet-shop-full/guardrailGenerate.dest/guardrail",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/server",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/server/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/models/definitions",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client/support",
+      "pet-shop-full/guardrailGenerate.dest/guardrail/client/definitions",
       "pet-shop-scala-akka-http/out/pet-shop-scala-akka-http/guardrailGenerate.dest/guardrail/client/definitions/Address.scala",
       "pet-shop-scala-akka-http/out/pet-shop-scala-akka-http/guardrailGenerate.dest/guardrail/client/definitions/ApiResponse.scala",
       "pet-shop-scala-akka-http/out/pet-shop-scala-akka-http/guardrailGenerate.dest/guardrail/client/definitions/Category.scala",
@@ -110,8 +118,21 @@ object `pet-shop-scala-akka-http` extends ScalaModule with Guardrail {
       "pet-shop-scala-akka-http/out/pet-shop-scala-akka-http/guardrailGenerate.dest/guardrail/models/Implicits.scala",
       "pet-shop-scala-akka-http/out/pet-shop-scala-akka-http/guardrailGenerate.dest/guardrail/models/support/Presence.scala"
     )
+    val generated = generatedSources().flatMap { entry =>
+      val withoutRefRegex = """^(?:[^:]+:){3}(.*)$""".r
+      val justPetShopFullRegex = """^.*/(pet-shop-full/.*)$""".r
+      val withoutRef = withoutRefRegex.replaceAllIn(
+        entry.toString.replaceAllLiterally("\\", "/"),
+        "$1"
+      )
+      os.walk(os.Path(withoutRef))
+        .map(f =>
+          justPetShopFullRegex
+            .replaceAllIn(f.toString().replaceAllLiterally("\\", "/"), "$1")
+        )
+    }
     assert(
-      generatedSources().exists(f =>
+      generated.exists(f =>
         expectedSources.exists(e =>
           f.toString.replaceAllLiterally("\\", "/").contains(e.toString)
         )

--- a/millguardrail/src-0.11/com/jackcviers/mill/guardrail/GuardrailPlatform.scala
+++ b/millguardrail/src-0.11/com/jackcviers/mill/guardrail/GuardrailPlatform.scala
@@ -22,7 +22,10 @@ import java.net.URLClassLoader
 
 trait GuardrailPlatform extends JavaModule { self: Guardrail =>
 
-  protected def guardrailWorkerRef = ModuleRef(GuardrailWorkerModule)
+  @deprecated("Performance: Use guardrailWorkerModule instead", "0.1.0-RC-7")
+  protected def guardrailWorkerRef = GuardrailWorkerModule
+
+  protected val guardrailWorkerModule = GuardrailWorkerModule
 
   private def guardrailClasspath: T[Seq[PathRef]] = T {
     resolveDeps(T.task {
@@ -32,7 +35,7 @@ trait GuardrailPlatform extends JavaModule { self: Guardrail =>
 
   protected def guardrailWorker
       : Task[(GuardrailWorker, GuardrailMillRunner, URLClassLoader)] = T.task {
-    guardrailWorkerRef()
+    guardrailWorkerModule
       .guardrailWorkerManager()
       .get(
         guardrailClasspath()

--- a/millguardrail/src/com/jackcviers/mill/guardrail/Guardrail.scala
+++ b/millguardrail/src/com/jackcviers/mill/guardrail/Guardrail.scala
@@ -129,7 +129,7 @@ trait Guardrail extends JavaModule with GuardrailPlatform {
     Thread.currentThread().setContextClassLoader(classLoader)
     val result = worker.guardrailGenerate(guardrailTasks(), runner)
     Thread.currentThread().setContextClassLoader(currentClassLoader)
-    result
+    Seq(PathRef(T.dest))
   }
 
   /** Add the necessary support modules for any generated classes. NOTE - you

--- a/millguardrail/src/com/jackcviers/mill/guardrail/GuardrailWorkerModule.scala
+++ b/millguardrail/src/com/jackcviers/mill/guardrail/GuardrailWorkerModule.scala
@@ -19,6 +19,7 @@ import mill.T
 import mill.define._
 
 trait GuardrailWorkerModule extends Module {
+
   def guardrailWorkerManager: Worker[GuardrailWorkerManager] = T.worker {
     new GuardrailWorkerManagerImplementation()
   }


### PR DESCRIPTION
* Changes guardrailGenerate to use task dest instead of the guardrail output

The Guardrail generator outputs raw file paths. However, this results in duplication when they are returned as the result of the `guardrailGenerate` task, which breaks `genIdea` imports:

```
...
2024-04-30 11:20:42 - Generating IDEA project files
[1/1] mill.scalalib.GenIdea.idea
Analyzing modules ...
[1/1] mill.scalalib.GenIdea.idea > [11/13] <redacted>.guardrailGenerate
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
<SFL4J warnings redacted>
[1/1] mill.scalalib.GenIdea.idea > [13/13] <redacted>.allSources
1 targets failed
mill.scalalib.GenIdea.idea java.lang.Exception: Duplicated item inserted into OrderedSet: /<redacted>/guardrailGenerate.dest/com/writer/guardrail/<redacted>.scala
    mill.api.AggWrapper$Agg$Mutable.append(AggWrapper.scala:99)
    mill.api.AggWrapper$Agg$Mutable$.$anonfun$from$1(AggWrapper.scala:60)
    scala.collection.IterableOnceOps.foreach(IterableOnce.scala:576)
    scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:574)
    scala.collection.AbstractIterator.foreach(Iterator.scala:1300)
    mill.api.AggWrapper$Agg$Mutable$.from(AggWrapper.scala:60)
    mill.api.AggWrapper$Agg$.from(AggWrapper.scala:56)
    mill.scalalib.GenIdeaImpl.$anonfun$xmlFileLayout$96(GenIdeaImpl.scala:568)
    scala.collection.immutable.Vector1.map(Vector.scala:2152)
    scala.collection.immutable.Vector1.map(Vector.scala:383)
    mill.scalalib.GenIdeaImpl.xmlFileLayout(GenIdeaImpl.scala:477)
    mill.scalalib.GenIdeaImpl.run(GenIdeaImpl.scala:41)
```

To fix this, we use the task source dest instead, which serves as the parent directory for the guardrail generator output. This prevents possible duplications from occuring in `genIdea`.